### PR TITLE
[테스트] 웹소켓 연결 및 메세지 송수신 테스트코드 작성

### DIFF
--- a/src/test/java/com/example/auctrade/AuctradeApplicationTests.java
+++ b/src/test/java/com/example/auctrade/AuctradeApplicationTests.java
@@ -3,7 +3,7 @@ package com.example.auctrade;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = AuctradeApplicationTests.class)
 class AuctradeApplicationTests {
 
     @Test

--- a/src/test/java/com/example/auctrade/chat/WebSocketTest.java
+++ b/src/test/java/com/example/auctrade/chat/WebSocketTest.java
@@ -138,6 +138,7 @@ class WebSocketTest {
         sendHeaders.setDestination("/send/chat/message");
         session.send(sendHeaders, mockMessage);
 
+        // then
         // 메시지 수신 확인(내용이 같은지)
         MessageDTO receivedMessage = future.get(5, TimeUnit.SECONDS);
         assertEquals(mockMessage.getMessage(), receivedMessage.getMessage(), "테스트 성공");

--- a/src/test/java/com/example/auctrade/chat/WebSocketTest.java
+++ b/src/test/java/com/example/auctrade/chat/WebSocketTest.java
@@ -1,0 +1,48 @@
+package com.example.auctrade.chat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.util.List;
+
+// 서버 포트번호 랜덤 설정, @LocalServerPort 기반 할당
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebSocketTest {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @LocalServerPort
+    private int port;
+
+    private String url;
+    private StompHeaders stompHeaders;
+
+    private WebSocketStompClient getStompClient() {
+        // WebSocketStompClient 인스턴스 설정
+        // SockJS 사용 고려
+        WebSocketStompClient stompClient =
+                new WebSocketStompClient(new SockJsClient(List.of(
+                        new WebSocketTransport(new StandardWebSocketClient()))));
+
+        // JSON 직렬화 및 역직렬화를 위한 converter 설정
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        return stompClient;
+    }
+
+    // 랜덤 포트 할당
+    @BeforeEach
+    void setUp() {
+        this.url = String.format("ws://localhost:%d/stomp/chat", port);
+    }
+
+}

--- a/src/test/java/com/example/auctrade/chat/WebSocketTest.java
+++ b/src/test/java/com/example/auctrade/chat/WebSocketTest.java
@@ -1,23 +1,31 @@
 package com.example.auctrade.chat;
 
+import com.example.auctrade.domain.chat.dto.MessageDTO;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // 서버 포트번호 랜덤 설정, @LocalServerPort 기반 할당
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WebSocketTest {
 
+    // 로그 기록
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @LocalServerPort
@@ -45,4 +53,16 @@ class WebSocketTest {
         this.url = String.format("ws://localhost:%d/stomp/chat", port);
     }
 
+    // 웹소켓 연결 확인
+    @Test
+    void testWebSocketConnection() throws Exception {
+        // given & when, then
+        WebSocketStompClient stompClient = getStompClient();
+        StompSession session = stompClient.connectAsync(
+                url, new StompSessionHandlerAdapter() {}).get(5, TimeUnit.SECONDS);
+
+        log.info("세션 연결: {}", session.isConnected());
+
+        assertTrue(session.isConnected(), "WebSocket 연결 성공");
+    }
 }

--- a/src/test/java/com/example/auctrade/global/config/WebSocketConfigTest.java
+++ b/src/test/java/com/example/auctrade/global/config/WebSocketConfigTest.java
@@ -1,4 +1,4 @@
-package com.example.auctrade.chat;
+package com.example.auctrade.global.config;
 
 import com.example.auctrade.domain.chat.dto.MessageDTO;
 import com.example.auctrade.domain.chat.service.ChatMessageService;
@@ -24,14 +24,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 // 서버 포트번호 랜덤 설정, @LocalServerPort 기반 할당
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class WebSocketTest {
+class WebSocketConfigTest {
 
     // 로그 기록
     private final Logger log = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
## 웹소켓 연결 확인
- 테스트 통과 여부:  성공
- 구현 : JUnit

## 웹소켓 기반 메세지 송수신 확인
- 테스트 통과 여부 : 성공
- 구현 : JUnit
- 기타 :
    - 메세지 송수신에 직접 관여하는 `ChatMessageService` 클래스 인스턴스 모킹 처리 후 확인
    - 향후, 인증 구현 및 웹소켓 관련 로직에 적용시, 테스트 코드 추가 설정 처리 필요